### PR TITLE
Changed padding of input to adapt to smaller modern phone sizes.

### DIFF
--- a/src/components/WaitlistForm.jsx
+++ b/src/components/WaitlistForm.jsx
@@ -75,7 +75,7 @@ const WaitlistSignup = ({ onSubmit }) => {
       flex: 1,
       backgroundColor: 'transparent',
       color: 'white',
-      padding: '0.75rem 1.5rem',
+      padding: '0.75rem 0.3rem 0.75rem 1.5rem',
       outline: 'none',
       border: 'none',
       fontSize: '1rem'


### PR DESCRIPTION
Adjusted padding for modern phone screens, smallest often being ~360, to stop the clipping of the join button.